### PR TITLE
Modified to use SocketHttpListener from NuGet

### DIFF
--- a/Grapevine/Grapevine.csproj
+++ b/Grapevine/Grapevine.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Grapevine</RootNamespace>
     <AssemblyName>Grapevine</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -32,7 +32,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -44,6 +43,12 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="Patterns.Logging">
+      <HintPath>packages\Patterns.Logging.1.0.0.2\lib\portable-net45+sl4+wp71+win8+wpa81\Patterns.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="SocketHttpListener">
+      <HintPath>packages\SocketHttpListener.1.0.0.13\lib\net45\SocketHttpListener.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -76,5 +81,8 @@
   -->
   <ItemGroup>
     <Folder Include="Util\Logging\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/Grapevine/Server/RouteCache.cs
+++ b/Grapevine/Server/RouteCache.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Reflection;
 using System.Text.RegularExpressions;
+
+using SocketHttpListener.Net;
 
 namespace Grapevine.Server
 {

--- a/Grapevine/Util/Responder.cs
+++ b/Grapevine/Util/Responder.cs
@@ -2,8 +2,9 @@
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Net;
 using System.Text;
+
+using SocketHttpListener.Net;
 
 namespace Grapevine
 {

--- a/Grapevine/packages.config
+++ b/Grapevine/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Patterns.Logging" version="1.0.0.2" targetFramework="net45" />
+  <package id="SocketHttpListener" version="1.0.0.13" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Because System.Net.HttpListener prevents access to WWW-Authenticate and other essential header values, now uses SocketHttpListener from NuGet, which is functionally equivalent as far as request handling is concerned. One less thread!

Now targets Framework v4.5 :( because SocketHttpListener uses 4.5-specific features. 